### PR TITLE
make adjustments for GHC 8 support

### DIFF
--- a/distributed-process-client-server.cabal
+++ b/distributed-process-client-server.cabal
@@ -17,7 +17,7 @@ description:    Modelled after Erlang OTP's gen_server, this framework provides 
                 development into a set of modules and standards designed to help you build
                 concurrent, distributed applications with relative ease.
 category:       Control
-tested-with:    GHC == 7.4.2 GHC == 7.6.2
+tested-with:    GHC == 7.4.2 GHC == 7.6.2 GHC == 8.0.1
 data-dir:       ""
 
 source-repository head
@@ -31,16 +31,17 @@ library
                    distributed-process >= 0.5.2 && < 0.7,
                    distributed-process-extras >= 0.2.0 && < 0.3,
                    distributed-process-async >= 0.2.1 && < 0.3,
-                   binary >= 0.6.3.0 && < 0.8,
-                   deepseq >= 1.3.0.1 && < 1.5,
+                   binary >= 0.6.3.0 && < 0.9,
+                   deepseq >= 1.3.0.1 && < 1.6,
                    mtl,
                    containers >= 0.4 && < 0.6,
                    hashable >= 1.2.0.5 && < 1.3,
                    unordered-containers >= 0.2.3.0 && < 0.3,
                    fingertree < 0.2,
                    stm >= 2.4 && < 2.5,
-                   time > 1.4 && < 1.6,
-                   transformers
+                   time > 1.4 && < 1.7,
+                   transformers,
+                   exceptions >= 0.5
   if impl(ghc <= 7.5)
     Build-Depends:   template-haskell == 2.7.0.0,
                      derive == 2.5.5,
@@ -85,7 +86,8 @@ test-suite ManagedProcessTests
                    test-framework-hunit,
                    transformers,
                    rematch >= 0.2.0.0,
-                   ghc-prim
+                   ghc-prim,
+                   exceptions >= 0.5
   hs-source-dirs:
                    tests
   ghc-options:     -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
@@ -117,7 +119,8 @@ test-suite PrioritisedProcessTests
                    test-framework-hunit,
                    transformers,
                    rematch >= 0.2.0.0,
-                   ghc-prim
+                   ghc-prim,
+                   exceptions >= 0.5
   hs-source-dirs:
                    tests
   ghc-options:     -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind

--- a/src/Control/Distributed/Process/ManagedProcess/Internal/Types.hs
+++ b/src/Control/Distributed/Process/ManagedProcess/Internal/Types.hs
@@ -49,7 +49,8 @@ module Control.Distributed.Process.ManagedProcess.Internal.Types
   , waitResponse
   ) where
 
-import Control.Distributed.Process hiding (Message)
+import Control.Distributed.Process hiding (Message, finally)
+import Control.Monad.Catch (finally)
 import qualified Control.Distributed.Process as P (Message)
 import Control.Distributed.Process.Serializable
 import Control.Distributed.Process.Extras
@@ -80,10 +81,11 @@ type CallId = MonitorRef
 
 newtype CallRef a = CallRef { unCaller :: (Recipient, CallId) }
   deriving (Eq, Show, Typeable, Generic)
-instance Serializable a => Binary (CallRef a) where
-instance NFData a => NFData (CallRef a) where rnf (CallRef x) = rnf x `seq` ()
+--instance Serializable a => Binary (CallRef a) where
+instance Binary (CallRef a) where
+instance NFData (CallRef a) where rnf (CallRef x) = rnf x `seq` ()
 
-makeRef :: forall a . (Serializable a) => Recipient -> CallId -> CallRef a
+makeRef :: Recipient -> CallId -> CallRef a
 makeRef r c = CallRef (r, c)
 
 instance Resolvable (CallRef a) where
@@ -232,8 +234,7 @@ instance Eq (ControlPort m) where
 
 -- | Obtain an opaque expression for communicating with a 'ControlChannel'.
 --
-channelControlPort :: (Serializable m)
-                   => ControlChannel m
+channelControlPort :: ControlChannel m
                    -> ControlPort m
 channelControlPort cc = ControlPort $ fst $ unControl cc
 

--- a/src/Control/Distributed/Process/ManagedProcess/Server/Restricted.hs
+++ b/src/Control/Distributed/Process/ManagedProcess/Server/Restricted.hs
@@ -59,7 +59,6 @@ module Control.Distributed.Process.ManagedProcess.Server.Restricted
   , say
   ) where
 
-import Control.Applicative (Applicative)
 import Control.Distributed.Process hiding (call, say)
 import qualified Control.Distributed.Process as P (say)
 import Control.Distributed.Process.Extras
@@ -73,7 +72,6 @@ import Prelude hiding (init)
 import Control.Monad.IO.Class (MonadIO)
 import qualified Control.Monad.State as ST
   ( MonadState
-  , MonadTrans
   , StateT
   , get
   , lift

--- a/tests/MathsDemo.hs
+++ b/tests/MathsDemo.hs
@@ -8,7 +8,6 @@ module MathsDemo
   , Add(..)
   ) where
 
-import Control.Applicative
 import Control.Distributed.Process hiding (call)
 import Control.Distributed.Process.Extras
 import Control.Distributed.Process.Extras.Time

--- a/tests/TestManagedProcess.hs
+++ b/tests/TestManagedProcess.hs
@@ -7,7 +7,7 @@ module Main where
 
 import Control.Concurrent.MVar
 import Control.Exception (SomeException)
-import Control.Distributed.Process hiding (call)
+import Control.Distributed.Process hiding (call, catch)
 import Control.Distributed.Process.Node
 import Control.Distributed.Process.Extras hiding (__remoteTable, monitor, send, nsend)
 import Control.Distributed.Process.ManagedProcess
@@ -30,6 +30,7 @@ import ManagedProcessCommon
 
 import qualified Network.Transport as NT
 import Control.Monad (void)
+import Control.Monad.Catch (catch)
 
 -- utilities
 

--- a/tests/TestPrioritisedProcess.hs
+++ b/tests/TestPrioritisedProcess.hs
@@ -10,7 +10,7 @@ module Main where
 import Control.Concurrent.MVar
 import Control.Exception (SomeException)
 import Control.DeepSeq (NFData)
-import Control.Distributed.Process hiding (call, send)
+import Control.Distributed.Process hiding (call, send, catch)
 import Control.Distributed.Process.Node
 import Control.Distributed.Process.Extras hiding (__remoteTable)
 import Control.Distributed.Process.Async
@@ -19,6 +19,7 @@ import Control.Distributed.Process.Tests.Internal.Utils
 import Control.Distributed.Process.Extras.Time
 import Control.Distributed.Process.Extras.Timer
 import Control.Distributed.Process.Serializable()
+import Control.Monad.Catch (catch)
 
 import Data.Binary
 import Data.Either (rights)

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -17,7 +17,6 @@ import Control.Distributed.Process.Node
 import Control.Distributed.Process.Extras
 import Control.Distributed.Process.Extras.Time
 import Control.Distributed.Process.Extras.Timer
-import Test.HUnit (Assertion, assertFailure)
 import Test.Framework (Test, defaultMain)
 
 import Network.Transport.TCP


### PR DESCRIPTION
* relax cabal upper bound constraints
* use Control.Monad.Catch (catch,finally) where appropriate as per deprecation warning
* fix unused import warnings

Ran "cabal test" against GHC 7.10.3 and GHC 8.0.1 successfully.

I need to compile against binary, time, and deepseq from GHC 8 because our [project](https://github.com/agentm/project-m36) links against GHC for its scripting engine.

The only remaining warnings in GHC8 are loads of redundant constraint warnings (new in GHC 8), but that will be fixed in a subsequent pull request, if it makes sense to fix them.