### PR TITLE
Safe Handler Execution

### DIFF
--- a/src/Control/Distributed/Process/ManagedProcess/Internal/Types.hs
+++ b/src/Control/Distributed/Process/ManagedProcess/Internal/Types.hs
@@ -447,6 +447,7 @@ channelControlPort cc = ControlPort $ fst $ unControl cc
 -- for internal use. For an API for working with filters,
 -- see "Control.Distributed.Process.ManagedProcess.Priority".
 data Filter s = FilterOk s
+              | FilterSafe s
               | forall m . (Show m) => FilterReject m s
               | FilterSkip s
               | FilterStop s ExitReason


### PR DESCRIPTION
Evaluating `safe` or `apiSafe` in a 'filters' block allows the user to mark
certain messages for safe handling. When marked thus, any matching handlers
for these messages are evaluated without fully de-queueing the message from
the priority queue, such that if we receive and handle (i.e. swallow) an
exit signal, the message will be available for re-processing. Only once a
message has been safely processed will it be fully dequeued from the internal
mailbox/queue.