### PR TITLE
Implement ProcessBecome

### DIFF
--- a/src/Control/Distributed/Process/ManagedProcess/Internal/Types.hs
+++ b/src/Control/Distributed/Process/ManagedProcess/Internal/Types.hs
@@ -447,6 +447,7 @@ channelControlPort cc = ControlPort $ fst $ unControl cc
 -- for internal use. For an API for working with filters,
 -- see "Control.Distributed.Process.ManagedProcess.Priority".
 data Filter s = FilterOk s
+              | FilterSafe s
               | forall m . (Show m) => FilterReject m s
               | FilterSkip s
               | FilterStop s ExitReason

--- a/src/Control/Distributed/Process/ManagedProcess/Internal/Types.hs
+++ b/src/Control/Distributed/Process/ManagedProcess/Internal/Types.hs
@@ -318,6 +318,7 @@ data ProcessAction s =
   | ProcessHibernate TimeInterval s -- ^ hibernate for /delay/
   | ProcessStop      ExitReason     -- ^ stop the process, giving @ExitReason@
   | ProcessStopping  s ExitReason   -- ^ stop the process with @ExitReason@, with updated state
+  | ProcessBecome    (ProcessDefinition s) s -- ^ changes the current process definition
 
 -- | Returned from handlers for the synchronous 'call' protocol, encapsulates
 -- the reply data /and/ the action to take after sending the reply. A handler

--- a/src/Control/Distributed/Process/ManagedProcess/Server.hs
+++ b/src/Control/Distributed/Process/ManagedProcess/Server.hs
@@ -32,6 +32,7 @@ module Control.Distributed.Process.ManagedProcess.Server
   , replyChan
   , reject
   , rejectWith
+  , become
     -- * Stateless actions
   , noReply_
   , haltNoReply_
@@ -188,6 +189,9 @@ hibernate d s = return $ ProcessHibernate d s
 --
 hibernate_ :: StatelessHandler s TimeInterval
 hibernate_ d = return . ProcessHibernate d
+
+become :: forall s . ProcessDefinition s -> s -> Action s
+become def st = return $ ProcessBecome def st
 
 -- | Instructs the process to terminate, giving the supplied reason. If a valid
 -- 'shutdownHandler' is installed, it will be called with the 'ExitReason'


### PR DESCRIPTION
Allow a managed process to change its process definition (the set of api, info, exit, and timeout handlers, plus the unhandled message policy) on the fly.